### PR TITLE
fix java.lang.unsupportedoperationexception

### DIFF
--- a/src/main/java/net/minecraft/client/resources/LanguageManager.java
+++ b/src/main/java/net/minecraft/client/resources/LanguageManager.java
@@ -45,8 +45,8 @@ public class LanguageManager implements IResourceManagerReloadListener {
     }
 
     public void onResourceManagerReload(IResourceManager resourceManager) {
-        List<String> list = List.of("en_US");
-
+        List<String> list = new ArrayList<>(List.of("en_US"));
+    
         if (!"en_US".equals(this.currentLanguage)) {
             list.add(this.currentLanguage);
         }


### PR DESCRIPTION
When the default lang used in your options isn't en_US, this exception will happen as you start minecraft

I create a ArrayList<> to solve it (maybe there is a better way??)